### PR TITLE
Fixed error with unexpected return when putting an incorrect id for than...

### DIFF
--- a/lib/bro.rb
+++ b/lib/bro.rb
@@ -41,7 +41,7 @@ command :thanks do |c|
       id = read_state[idkey.intern]
 
       if id.nil?
-        say "That id (#{idkey}) does not exist for #{cmd}, try another one"
+        say "\nThat id (#{idkey}) does not exist for #{cmd}, try another one"
       end
 
       unless id.nil?


### PR DESCRIPTION
Terminal was printing "Error: Unexpected return.  View stack trace with --trace" before because it was returning early.  Wrapped everything inside an "unless" to fix that.
