### PR TITLE
Add default value for remote submission

### DIFF
--- a/lib/bro.rb
+++ b/lib/bro.rb
@@ -158,7 +158,7 @@ command :add do |c|
           QQQ
         entry = ask_editor prompt, "vim"
         if entry.gsub(prompt, '').strip.length > 0
-          if agree "Submit this entry for #{cmd}? [Yn] "
+          if agree("Submit this entry for #{cmd}? [y/n] ") {|q| q.default = "yes"}
             say "All right, sending your entry...".status
             begin
               res = RestClient.post URL + '/', login_details.merge({ entry: { cmd: cmd, msg: entry}, format: 'json', multipart: true })


### PR DESCRIPTION
Previously, the Y in [Yn] was capitalised, which normally indicates that Y is the default value - but it wasn't. This makes 'yes' the default value when the user is asked if they wish to submit their bropage, allowing them to press enter, rather than having to provide an answer to the question.
