### PR TITLE
Don't repeat how to upvote/downvote every line

### DIFF
--- a/lib/bro.rb
+++ b/lib/bro.rb
@@ -249,8 +249,13 @@ command :lookup do |c|
         (HighLine::SystemExtensions.terminal_size[0] - 5).times { sep += "." }
         sep += "\n"
 
+        upstr = "upvote"
+        downstr = "downvote"
+        say "\"bro thanks <id>\" to #{upstr.colored.green}"
+        say "\"bro ...no <id>\" to #{downstr.colored.red}"
+        say "\n"
+
         i = 0
-        isDefault = true
         list.each {|data|
             i += 1
 
@@ -258,27 +263,17 @@ command :lookup do |c|
             obj["#{i}"] = data['id']
             state.write_state(obj)
 
-            days = (DateTime.now - DateTime.parse(data['updated_at'])).ceil.to_i
-
             body = data['msg']
 
-            body = body.gsub(/^([^#][^\n]*)$/, "\\1".important)
+            body = body.gsub(/^([^#][^\n]*)$/, "    $ \\1".important)
+            body = body.gsub(/^(# )/, "#{i}. ")
 
-            say sep + "\n" if i > 1
+            up = "#{data['up']}".colored.green
+            down = "#{data['down']}".colored.red
+            body = body.gsub(/^(\d+\..*)$/, "\\1 (#{up}, #{down})")
 
-            say body + "\n\n"
-
-            upstr = "bro thanks"
-            upstr += " #{i}" unless isDefault
-            downstr = "bro ...no"
-            downstr += " #{i}" unless isDefault
-
-            msg = "\t#{upstr.colored.green}\tto upvote (#{data['up']})\n\t#{downstr.colored.red}\tto downvote (#{data['down']})"
-            if days > 0
-              #msg += "\tlast updated\t#{days} days ago"
-            end
-            say msg + "\n\n"
-            isDefault = false
+            say "\n" if i > 1
+            say "#{body} \n"
         }
 
       end


### PR DESCRIPTION
Make the output more compact by telling the user what the
upvote/downvote commands once at the stop of the output
rather than for every entry.

Show id, upvotes and downvotes for each entry after the comment,
in the format (id: upvotes, downvotes).

![screen shot 2014-01-26 at 21 13 41](https://f.cloud.github.com/assets/802125/2005066/c73a2648-86ce-11e3-9fd7-8dcdeba4fc87.png)
