### PR TITLE
Rest-client >1.7.0 doesn't support ruby 1.8.7

### DIFF
--- a/bro.gemspec
+++ b/bro.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables << 'bro'
   s.add_runtime_dependency 'json_pure', '1.8.1'
   s.add_runtime_dependency 'commander', '4.1.5'
-  s.add_runtime_dependency 'rest-client'
+  s.add_runtime_dependency 'rest-client', '<=1.7.0'
   s.add_runtime_dependency 'smart_colored'
   s.add_runtime_dependency 'highline', '1.6.20'
   s.add_runtime_dependency 'mime-types', '~> 1.19.0'


### PR DESCRIPTION
Since version 1.7.2 rest-client doesn't support ruby 1.8.7.

Locked version of rest-client to <= 1.7.0 as newer versions require ruby > 1.9.2

I've locked it to this version as it appears to be the latest one with 1.8.7 support.