### PR TITLE
Specify license and smart_colored version

### DIFF
--- a/bro.gemspec
+++ b/bro.gemspec
@@ -15,11 +15,12 @@ Gem::Specification.new do |s|
                     "lib/bro/string_hacks.rb",
                     "lib/bro/version.rb"]
   s.homepage    = 'http://bropages.org'
+  s.license     = 'BSD-2-Clause'
   s.executables << 'bro'
   s.add_runtime_dependency 'json_pure', '1.8.1'
   s.add_runtime_dependency 'commander', '4.1.5'
   s.add_runtime_dependency 'rest-client', '<=1.7.0'
-  s.add_runtime_dependency 'smart_colored'
+  s.add_runtime_dependency 'smart_colored', '~> 1.1.1'
   s.add_runtime_dependency 'highline', '1.6.20'
   s.add_runtime_dependency 'mime-types', '~> 1.19.0'
 end


### PR DESCRIPTION
When running `gem build bro.gemspec` we see this issue:

WARNING:  licenses is empty, but is recommended.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
WARNING:  open-ended dependency on smart_colored (>= 0) is not recommended
  if smart_colored is semantically versioned, use:
    add_runtime_dependency 'smart_colored', '~> 0'