### PR TITLE
Upgrade ruby commander to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     bropages (0.1.0)
       commander (= 4.4.7)
-      highline (~> 2.0.0)
+      highline (~> 2.0.1)
       json_pure (= 1.8.1)
       mime-types (~> 1.19.0)
       rest-client (<= 1.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,25 +2,25 @@ PATH
   remote: .
   specs:
     bropages (0.1.0)
-      commander (= 4.1.5)
-      highline (= 1.6.20)
+      commander (= 4.4.7)
+      highline (~> 2.0.0)
       json_pure (= 1.8.1)
       mime-types (~> 1.19.0)
-      rest-client
+      rest-client (<= 1.7.0)
       smart_colored
 
 GEM
   remote: https://rubygems.org/
   specs:
-    commander (4.1.5)
-      highline (~> 1.6.11)
+    commander (4.4.7)
+      highline (~> 2.0.0)
     diff-lcs (1.2.5)
-    highline (1.6.20)
+    highline (2.0.1)
     json_pure (1.8.1)
     mime-types (1.19)
     rake (10.1.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.6.9)
+      mime-types (~> 1.16)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -38,3 +38,6 @@ DEPENDENCIES
   bropages!
   rake
   rspec
+
+BUNDLED WITH
+   1.17.3

--- a/bro.gemspec
+++ b/bro.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'commander', '4.4.7'
   s.add_runtime_dependency 'rest-client', '<=1.7.0'
   s.add_runtime_dependency 'smart_colored'
-  s.add_runtime_dependency 'highline', '~> 2.0.0'
+  s.add_runtime_dependency 'highline', '~> 2.0.1'
   s.add_runtime_dependency 'mime-types', '~> 1.19.0'
 end

--- a/bro.gemspec
+++ b/bro.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://bropages.org'
   s.executables << 'bro'
   s.add_runtime_dependency 'json_pure', '1.8.1'
-  s.add_runtime_dependency 'commander', '4.1.5'
+  s.add_runtime_dependency 'commander', '4.4.7'
   s.add_runtime_dependency 'rest-client', '<=1.7.0'
   s.add_runtime_dependency 'smart_colored'
-  s.add_runtime_dependency 'highline', '1.6.20'
+  s.add_runtime_dependency 'highline', '~> 2.0.0'
   s.add_runtime_dependency 'mime-types', '~> 1.19.0'
 end

--- a/lib/bro.rb
+++ b/lib/bro.rb
@@ -280,7 +280,7 @@ command :lookup do |c|
         QQQ
 
         sep = ""
-        (HighLine::SystemExtensions.terminal_size[0] - 5).times { sep += "." }
+        (HighLine.new.output_cols - 5).times { sep += "." }
         sep += "\n"
 
         i = 0


### PR DESCRIPTION
This should fix deprecation warnings we've been seeing on newer ruby versions...

Requires fixing the HighLine call to determine width, which now seems broken (at least on my MacOS console), while `HighLine::SystemExtensions.terminal_size` was working for me just fine. It seems like a recent regression in Highline but that is an issue for another day.

Fix #67 (but causes only 80 separator dots to print on MacOS Mojave at least)